### PR TITLE
Respect routing candidate set protocol type

### DIFF
--- a/apps/hellgate/test/hg_invoice_tests_SUITE.erl
+++ b/apps/hellgate/test/hg_invoice_tests_SUITE.erl
@@ -8028,8 +8028,8 @@ construct_domain_fixture() ->
             ?ruleset(6),
             <<"SubMain">>,
             {candidates, [
-                ?candidate(<<"High priority">>, {constant, true}, ?trm(12), 1010),
                 ?candidate(<<"Middle priority">>, {constant, true}, ?trm(13), 1005),
+                ?candidate(<<"High priority">>, {constant, true}, ?trm(12), 1010),
                 ?candidate({constant, true}, ?trm(14))
             ]}
         ),


### PR DESCRIPTION
Otherwise we'll fail miserably while trying to serialize event with ill-formed set of candidates.