### PR TITLE
CM-25: Adds crutch for serving legacy plan ids

### DIFF
--- a/apps/hellgate/src/hg_accounting.erl
+++ b/apps/hellgate/src/hg_accounting.erl
@@ -47,6 +47,7 @@
 
 -export_type([plan_id/0]).
 -export_type([batch/0]).
+-export_type([posting_plan_log/0]).
 
 -type account() :: #{
     account_id => account_id(),


### PR DESCRIPTION
`commit_payment_cashflow` and `rollback_payment_cashflow` will try legacy plan id construction if normal not found.