### PR TITLE
TD-656: Adds route candidates condition

### DIFF
--- a/apps/hellgate/src/hg_invoice_payment.erl
+++ b/apps/hellgate/src/hg_invoice_payment.erl
@@ -3662,6 +3662,9 @@ get_party_client() ->
 
 is_route_cascade_available(?failed(OperationFailure), #st{routes = AttemptedRoutes} = St) ->
     is_failure_cascade_trigger(OperationFailure) andalso
+        %% For cascade viability we require at least one more route candidate
+        %% provided by recent routing.
+        length(get_candidate_routes(St)) > 1 andalso
         length(AttemptedRoutes) < get_routing_attempt_limit(St).
 
 is_failure_cascade_trigger({failure, Failure}) ->

--- a/apps/hellgate/test/hg_route_rules_tests_SUITE.erl
+++ b/apps/hellgate/test/hg_route_rules_tests_SUITE.erl
@@ -98,6 +98,7 @@ init_per_suite(C) ->
     _ = unlink(SupPid),
     _ = mock_dominant(SupPid),
     _ = mock_party_management(SupPid),
+    _ = mock_fault_detector(SupPid),
     [
         {apps, Apps},
         {suite_test_sup, SupPid},
@@ -649,9 +650,7 @@ routes_selected_with_risk_score(_C, RiskScore, ProviderRefs) ->
     ?assert_set_equal(ProviderRefs, lists:map(fun hg_routing:provider_ref/1, Routes)).
 
 -spec choice_context_formats_ok(config()) -> test_return().
-choice_context_formats_ok(C) ->
-    _ = mock_fault_detector(?config(suite_test_sup, C)),
-
+choice_context_formats_ok(_C) ->
     Route1 = hg_routing:new(?prv(1), ?trm(1)),
     Route2 = hg_routing:new(?prv(2), ?trm(2)),
     Route3 = hg_routing:new(?prv(3), ?trm(3)),


### PR DESCRIPTION
Removes obsolete testcase `payment_cascade_no_route`